### PR TITLE
Feature/speed up

### DIFF
--- a/ChartAnalyzer.py
+++ b/ChartAnalyzer.py
@@ -1,8 +1,26 @@
+import functools
+
 from CoordinateTimeTuple import CoordinateTimeTuple
 from Note import Note
 import re
+import time
 
 
+def measure(func):
+    @functools.wraps(func)
+    def wrapper(*args, **kargs):
+        start_time = time.time()
+
+        result = func(*args, **kargs)
+
+        execution_time = time.time() - start_time
+        print(f'{func.__name__}: {execution_time}')
+        return result
+
+    return wrapper
+
+
+@measure
 def load(path):
     file = open(path, 'r')
 
@@ -33,8 +51,8 @@ def load(path):
 
     total_time = 0
     bpm = 200
+    notes = []
     for i, measure in enumerate(measures):
-        notes = []
         coordinates = measure[0]
         times = measure[1]
         for time in times:
@@ -43,12 +61,6 @@ def load(path):
                 total_time += 60000.0 / bpm / split_size
                 if c == '－':
                     continue
-                notes.append(Note(c, total_time, [], bpm))
+                notes.append(Note(c, total_time, [(i % 16) + 1 for i, x in enumerate(coordinates) if x == c], bpm))
 
-        for j, note in enumerate(notes):
-            note.positions = [(i % 16) + 1 for i, x in enumerate(coordinates) if x == note.note]
-            notes[j] = note
-
-        measures[i] = list(notes)
-
-    return measures
+    return notes

--- a/ChartAnalyzer.py
+++ b/ChartAnalyzer.py
@@ -42,7 +42,7 @@ def load(path):
         for time in times:
             for c in time:
                 split_size = len(time)
-                total_time += 60000.0 / bpm / split_size
+                total_time += 60000.0 / bpm / split_size  # TODO 口⑤口口 |④－| の表記の対処法
                 if c == '－':
                     continue
                 notes.append(Note(c, total_time, [(i % 16) + 1 for i, x in enumerate(coordinates) if x == c], bpm))

--- a/ChartAnalyzer.py
+++ b/ChartAnalyzer.py
@@ -1,26 +1,10 @@
-import functools
-
 from CoordinateTimeTuple import CoordinateTimeTuple
 from Note import Note
 import re
-import time
+import utils
 
 
-def measure(func):
-    @functools.wraps(func)
-    def wrapper(*args, **kargs):
-        start_time = time.time()
-
-        result = func(*args, **kargs)
-
-        execution_time = time.time() - start_time
-        print(f'{func.__name__}: {execution_time}')
-        return result
-
-    return wrapper
-
-
-@measure
+@utils.measure
 def load(path):
     file = open(path, 'r')
 

--- a/main.py
+++ b/main.py
@@ -1,16 +1,14 @@
 # -*- coding: utf-8 -*-
 import math
-
 import numpy as np
-import time
 import pygame
-import sys
+import utils
 from gevent import os
 from pygame.locals import *
-
 from ChartAnalyzer import load
 
 
+@utils.measure
 def split_image(image):
     imageList = []
     for i in range(0, 800, 160):
@@ -22,6 +20,7 @@ def split_image(image):
     return imageList
 
 
+@utils.measure
 def get_nearest_value(list, num):
     """
     概要: リストからある値に最も近い値を返却する関数
@@ -51,6 +50,7 @@ def get_marker_frames(notes, music_pos):
     return list(within_notes)
 
 
+@utils.measure
 def play(music, fumen):
     screen = pygame.display.set_mode((640 + 32 * 5, 640 + 32 * 5))
     front_mask = pygame.image.load(os.path.join('img', 'front.png'))
@@ -76,17 +76,16 @@ def play(music, fumen):
 
         for event in pygame.event.get():
             if event.type == QUIT:
-                pygame.quit()
-                sys.exit()
+                return
             if event.type == TRACK_END:
                 pygame.mixer.music.stop()
                 pygame.mixer.music.play()
 
         screen.blit(front_mask, (0, 0))
-
         pygame.display.update()
 
 
+@utils.measure
 def pygame_init():
     pygame.mixer.quit()
     pygame.mixer.init(frequency=44100, size=-16, channels=2, buffer=1024)
@@ -94,7 +93,5 @@ def pygame_init():
 
 
 if __name__ == "__main__":
-    start = time.time()
     pygame_init()
     play('Stand Alone Beat Masta.mp3', 'fumen/sample.jbt')
-    print("elapsed_time:{0}".format(time.time() - start) + "[sec]")

--- a/main.py
+++ b/main.py
@@ -57,18 +57,9 @@ def play(music, fumen):
     maker_frames = split_image(pygame.image.load(os.path.join('img', 'blur.png')).convert_alpha())
     background = pygame.transform.rotozoom(pygame.image.load(os.path.join('img', 'ble.png')), 0.0, 800 / 950)
     handclap = pygame.mixer.Sound("handclap.wav")
+    notes = load(fumen)
 
-    measures = load(fumen)
-    notes = []
-    for measure in measures:
-        for note in measure:
-            notes.append(note)
-            note.print()
-
-    PANEL_POSITIONS = []
-    for i in range(32, 640, 160 + 32):
-        for j in range(32, 640, 160 + 32):
-            PANEL_POSITIONS.append([j, i])
+    PANEL_POSITIONS = [(y, x) for x in range(32, 640, 160 + 32) for y in range(32, 640, 160 + 32)]
 
     TRACK_END = USEREVENT + 1
     pygame.mixer.music.set_endevent(TRACK_END)
@@ -92,6 +83,7 @@ def play(music, fumen):
                 pygame.mixer.music.play()
 
         screen.blit(front_mask, (0, 0))
+
         pygame.display.update()
 
 

--- a/main.py
+++ b/main.py
@@ -1,5 +1,7 @@
 # -*- coding: utf-8 -*-
 import math
+import sys
+
 import numpy as np
 import pygame
 import utils
@@ -93,5 +95,8 @@ def pygame_init():
 
 
 if __name__ == "__main__":
-    pygame_init()
-    play('Stand Alone Beat Masta.mp3', 'fumen/sample.jbt')
+    if 2 <= len(sys.argv) <= 3:
+        pygame_init()
+        play(sys.argv[1], sys.argv[2])
+    else:
+        print('Invalid argument error!!')

--- a/utils.py
+++ b/utils.py
@@ -1,0 +1,16 @@
+import functools
+import time
+
+
+def measure(func):
+    @functools.wraps(func)
+    def wrapper(*args, **kargs):
+        start_time = time.time()
+
+        result = func(*args, **kargs)
+
+        execution_time = time.time() - start_time
+        print('%.2f[ms] @%s' % (execution_time * 1000, func.__name__))
+        return result
+
+    return wrapper


### PR DESCRIPTION
## 譜面ロード時間の短縮
### play(music, fumen) 開始時からメインループの直前まで(5回平均)
- before; 0.58861768245 [sec]
- after; 0.50025224685 [sec]
- diff; 0.0883654356 [sec]

約15%OFF!!

@utils.measure をメソッド名の先頭に付けると
そのメソッドの処理時間が表示される